### PR TITLE
fix: improve English naturalness in documentation

### DIFF
--- a/CLAUDE_en.md
+++ b/CLAUDE_en.md
@@ -34,7 +34,7 @@
 - **File Editing**: Modification/updating of existing files
 - **Documentation**: Updates to README, specifications (create new only when requested)
 - **Dependencies**: Package addition/updating/removal
-- **Tests**: Implementation of unit/integration tests (follow TDD cycle)
+- **Tests**: Implementing unit/integration tests (follow TDD cycle)
 - **Settings**: Configuration value changes, format application
 
 ### Confirmation Required
@@ -43,7 +43,7 @@
 - **File Deletion**: Deletion of important files
 - **Structural Changes**: Large-scale changes to architecture, folder structure
 - **External Integration**: Introduction of new APIs, external libraries
-- **Security**: Implementation of authentication/authorization features
+- **Security**: Implementing authentication/authorization features
 - **Database**: Schema changes, migrations
 - **Production Environment**: Deployment settings, environment variable changes
 

--- a/commands/check-github-ci.md
+++ b/commands/check-github-ci.md
@@ -1,4 +1,4 @@
-## GitHub CI 監視
+## GitHub CI Monitoring
 
 GitHub Actions CI 状況を監視して、完了まで追跡します。
 

--- a/locales/en/agents/roles/reviewer.md
+++ b/locales/en/agents/roles/reviewer.md
@@ -226,7 +226,7 @@ Technical Debt: 2.5 days (Requires action)
 ### Typical Discussion Points
 
 - Optimization of "readability vs performance"
-- Judgment of "DRY vs YAGNI"
+- Evaluating "DRY vs YAGNI"
 - Appropriateness of "abstraction level"
 - "Test coverage vs development speed"
 

--- a/locales/en/agents/roles/security.md
+++ b/locales/en/agents/roles/security.md
@@ -125,7 +125,7 @@ Say these to activate this role:
 
 ### Threat Modeling Enhancement
 
-#### Systematic Analysis of Attack Vectors
+#### Systematically Analyzing Attack Vectors
 
 1. **STRIDE Method**: Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege
 2. **Attack Tree Analysis**: Step-by-step decomposition of attack paths
@@ -277,7 +277,7 @@ Conduct security audits specialized for generative AI and agent systems. Comply 
 
 #### LLM05: Inappropriate Output Handling
 
-**Risk Assessment During System Integration**:
+**Risk Assessment for System Integration**:
 
 - Possibility of SQL/NoSQL injection
 - Code execution vulnerabilities (eval, exec)

--- a/locales/en/commands/check-prompt.md
+++ b/locales/en/commands/check-prompt.md
@@ -184,7 +184,7 @@ cat devin/playbooks/code-review.md
 - [ ] Machine learning-based analysis of failure patterns
 - [ ] Automatic update mechanism for best practices
 
-#### 6.2 Implementation of Learning Functions (5 points)
+#### 6.2 Implementing Learning Functions (5 points)
 
 - [ ] Automatic detection and classification of new patterns
 - [ ] Continuous monitoring of effectiveness of existing rules
@@ -302,7 +302,7 @@ Bonus elements:
 Final score = Basic score + Bonus - Penalties
 ```
 
-### Quality Level Judgment
+### Quality Level Assessment
 
 ```
 95-100 points: World's highest standard (Recommended as industry standard)
@@ -407,7 +407,7 @@ Quality score: 90/100 points (+20 points improvement)
 - Error handling: 90% of problems solved automatically
 
 Actual improvement effects:
-- Judgment errors: 85% reduction
+- Assessment errors: 85% reduction
 - Execution time: 40% reduction
 - Error occurrence rate: 70% reduction
 - User satisfaction: 95% improvement

--- a/locales/en/commands/commit-message.md
+++ b/locales/en/commands/commit-message.md
@@ -96,7 +96,7 @@ export default {
 }
 ```
 
-#### 3. Language Setting Detection
+#### 3. Detecting Language Settings
 
 ```javascript
 // When project uses Japanese messages

--- a/locales/en/commands/pr-create.md
+++ b/locales/en/commands/pr-create.md
@@ -139,14 +139,14 @@ mcp_github_create_pull_request({
 
 ### Auto Label Selection System
 
-#### File Pattern Based Determination
+#### Determining from File Patterns
 
 - **Documentation**: `*.md`, `README`, `docs/` → `documentation|docs|doc`
 - **Tests**: `test`, `spec` → `test|testing`
 - **CI/CD**: `.github/`, `*.yml`, `Dockerfile` → `ci|build|infra|ops`
 - **Dependencies**: `package.json`, `pubspec.yaml` → `dependencies|deps`
 
-#### Content Based Determination
+#### Determining from Content
 
 - **Bug fixes**: `fix|bug|error|crash|repair` → `bug|fix`
 - **New features**: `feat|feature|add|implement|new-feature|implementation` → `feature|enhancement|feat`

--- a/locales/en/commands/pr-feedback.md
+++ b/locales/en/commands/pr-feedback.md
@@ -94,7 +94,7 @@ git diff HEAD~1
 ### Response Flow
 
 1. **Comment analysis**: Classification by priority
-2. **Fix plan**: Determination of response order
+2. **Fix plan**: Determining response order
 3. **Phased fixes**: Critical → High → Medium → Low
 4. **Quality confirmation**: Testing, linting, building
 5. **Progress report**: Description of specific fixes

--- a/locales/en/commands/pr-issue.md
+++ b/locales/en/commands/pr-issue.md
@@ -39,7 +39,7 @@ Open Issues List (by Priority)
 (Similar format)
 ```
 
-### Priority Determination Criteria
+### Priority Assessment Criteria
 
 **High Priority**
 

--- a/locales/en/commands/pr-list.md
+++ b/locales/en/commands/pr-list.md
@@ -39,7 +39,7 @@ Open PRs List (by Priority)
 (Similar format)
 ```
 
-### Priority Determination Criteria
+### Priority Assessment Criteria
 
 **High Priority**
 

--- a/locales/en/commands/role-debate.md
+++ b/locales/en/commands/role-debate.md
@@ -83,7 +83,7 @@ Exploration of implementable solutions
 
 ### Phase 4: Integrated Conclusion
 
-Determination of final recommendations
+Determining final recommendations
 
 - Agreed-upon solution
 - Implementation roadmap

--- a/locales/en/commands/semantic-commit.md
+++ b/locales/en/commands/semantic-commit.md
@@ -379,7 +379,7 @@ for group in $GROUPS; do
 done
 ```
 
-##### Step 3: Similarity Analysis of Changes
+##### Step 3: Analyzing Change Similarity
 
 ```bash
 # Analyze change type for each file
@@ -440,7 +440,7 @@ git diff HEAD --name-only | while read file; do
 done
 ```
 
-##### Step 6: Final Group Determination
+##### Step 6: Determining Final Groups
 
 ```bash
 # Verify split results
@@ -506,7 +506,7 @@ or
 feat(api)!: change authentication flow
 ```
 
-#### Automatic Detection of Project Conventions
+#### Automatically Detecting Project Conventions
 
 **Important**: If project-specific conventions exist, they take precedence.
 
@@ -531,7 +531,7 @@ cat .commitlintrc.json
 grep -A 10 '"commitlint"' package.json
 ```
 
-##### 2. Detection of Custom Types
+##### 2. Detecting Custom Types
 
 Example of project-specific types:
 
@@ -556,7 +556,7 @@ export default {
 }
 ```
 
-##### 3. Language Setting Detection
+##### 3. Detecting Language Settings
 
 ```javascript
 // When project uses Japanese messages
@@ -726,7 +726,7 @@ We check for config files in this order:
    head -20
    ```
 
-#### Analysis of Configuration Examples
+#### Analyzing Configuration Examples
 
 **Standard commitlint.config.mjs**:
 

--- a/locales/en/commands/smart-review.md
+++ b/locales/en/commands/smart-review.md
@@ -9,9 +9,9 @@ A command that analyzes the current situation and automatically suggests the opt
 /smart-review <file/directory>   # Analyze specific target
 ```
 
-### Automatic Judgment Logic
+### Automatic Analysis Logic
 
-### Judgment by File Extension
+### Analysis by File Extension
 
 - `package.json`, `*.tsx`, `*.jsx`, `*.css`, `*.scss` → **frontend**
 - `Dockerfile`, `docker-compose.yml`, `*.yaml` → **architect**
@@ -24,7 +24,7 @@ A command that analyzes the current situation and automatically suggests the opt
 - `login.tsx`, `signup.js`, `jwt.js` → **security + frontend**
 - `api/auth/`, `middleware/auth/` → **security + architect**
 
-### Complex Judgment Patterns
+### Complex Analysis Patterns
 
 - `mobile/` + `*.swift`, `*.kt`, `react-native/` → **mobile**
 - `webpack.config.js`, `vite.config.js`, `large-dataset/` → **performance**
@@ -60,7 +60,7 @@ $ /smart-review src/mobile/components/
 → "[4] role-debate mobile,frontend"
 ```
 
-### Suggestion During Problem Analysis
+### Suggestions for Problem Analysis
 
 ```bash
 $ /smart-review error.log
@@ -73,7 +73,7 @@ $ /smart-review slow-api.log
 → "Recommended: [1]/role performance [2]/role-debate performance,analyzer"
 ```
 
-### Suggestion During Complex Design Decisions
+### Suggestions for Complex Design Decisions
 
 ```bash
 $ /smart-review architecture-design.md
@@ -83,9 +83,9 @@ $ /smart-review architecture-design.md
 → "[Alternative] /multi-role architect,security,performance"
 ```
 
-### Details of Suggestion Logic
+### Suggestion Logic Details
 
-### Priority Judgment
+### Priority Assessment
 
 1. **Security** - Authentication, authorization, and encryption are top priorities
 2. **Critical Errors** - System outages and data loss are urgent


### PR DESCRIPTION
## What does this change?

This PR improves the naturalness of English expressions in the documentation and command files.

### Main changes

- **Language quality**: Replaced unnatural noun phrases with gerund forms
- **Word choice**: Changed "Judgment" to "Assessment/Analysis" for better clarity
- **Grammar**: Fixed direct translations from Japanese patterns
- **Consistency**: Improved overall English readability

### Details

#### Files modified (13 files)
- `CLAUDE_en.md`: Fixed "Implementation of" → "Implementing"
- `commands/check-github-ci.md`: Corrected Japanese text to English
- `locales/en/agents/roles/`: Improved expressions in reviewer and security docs
- `locales/en/commands/`: Enhanced naturalness in multiple command documentation files

#### Types of improvements
1. **Noun phrases to gerunds**: More natural for English headings
   - "Detection of" → "Detecting"
   - "Analysis of" → "Analyzing"
   - "Implementation of" → "Implementing"

2. **Better word choices**:
   - "Judgment" → "Assessment/Evaluation"
   - "Determination" → "Assessment/Determining"
   - "During" → "for" in appropriate contexts

3. **Grammar corrections**:
   - Fixed awkward constructions like "Based Determination"
   - Improved verb forms in headings

### Impact
- ✅ No information loss - only word replacements
- ✅ No content addition - maintained original meaning
- ✅ Minimal changes - only clearly unnatural expressions were corrected